### PR TITLE
Include min sdk version requirement

### DIFF
--- a/packages/phone_log/CHANGELOG.md
+++ b/packages/phone_log/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.4] - July 30th, 2019
+Add minimum sdk version of 16 for the plugin.
+
 ## [0.0.3] - August 15th, 2018.
 Update 'checkPermission' method.
 

--- a/packages/phone_log/android/src/main/AndroidManifest.xml
+++ b/packages/phone_log/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.jiajiabingcheng.phonelog">
-    <uses-permission android:name="android.permission.READ_CALL_LOG"/>
+  <uses-sdk android:minSdkVersion="16" />
+  <uses-permission android:name="android.permission.READ_CALL_LOG"/>
 </manifest>

--- a/packages/phone_log/pubspec.yaml
+++ b/packages/phone_log/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phone_log
 description: A new flutter plugin project.
-version: 0.0.3
+version: 0.0.4
 author: Jiaming Cheng <jiamingc@google.com>
 homepage: https://github.com/jiajiabingcheng/phone_log
 


### PR DESCRIPTION
Right now flutter supports a minimum SDK version of 16 and all plugins should be able to match it, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it.