### PR TITLE
Fix Android MediaPlayer.setDataSource() calls to allow older SDK vers…

### DIFF
--- a/packages/audiofileplayer/android/src/main/java/com/google/flutter/plugins/audiofileplayer/AudiofileplayerPlugin.java
+++ b/packages/audiofileplayer/android/src/main/java/com/google/flutter/plugins/audiofileplayer/AudiofileplayerPlugin.java
@@ -141,8 +141,7 @@ public class AudiofileplayerPlugin implements MethodCallHandler {
       } else if (call.argument(AUDIO_BYTES) != null) {
         byte[] audioBytes = call.argument(AUDIO_BYTES);
         ManagedMediaPlayer newPlayer =
-            new LocalManagedMediaPlayer(
-                audioId, new BufferMediaDataSource(audioBytes), this, looping);
+            new LocalManagedMediaPlayer(audioId, audioBytes, this, looping, registrar.context());
         mediaPlayers.put(audioId, newPlayer);
         handleDurationForPlayer(newPlayer, audioId);
         result.success(null);


### PR DESCRIPTION
…ions

Works around calls to 
MediaPlayer.setDataSource(MediaDataSource) 
and
MediaPlayer.setDataSource(AssetFileDescriptor)
which are both added to recent APIs. 

Now, there should be compatibility to the stated minSdk of 16.