### PR TITLE
Update error handling to avoid null pointer exceptions

### DIFF
--- a/packages/audiofileplayer/android/src/main/java/com/google/flutter/plugins/audiofileplayer/AudiofileplayerPlugin.java
+++ b/packages/audiofileplayer/android/src/main/java/com/google/flutter/plugins/audiofileplayer/AudiofileplayerPlugin.java
@@ -74,6 +74,7 @@ public class AudiofileplayerPlugin implements MethodCallHandler {
     }
     // All subsequent calls need a valid player.
     ManagedMediaPlayer player = getAndVerifyPlayer(call, result);
+
     if (call.method.equals(PLAY_METHOD)) {
       Boolean playFromStartBoolean = call.argument(PLAY_FROM_START);
       boolean playFromStart = playFromStartBoolean.booleanValue();
@@ -135,6 +136,7 @@ public class AudiofileplayerPlugin implements MethodCallHandler {
         String key = registrar.lookupKeyForAsset(flutterPath);
         AssetFileDescriptor fd = assetManager.openFd(key);
         ManagedMediaPlayer newPlayer = new LocalManagedMediaPlayer(audioId, fd, this, looping);
+        fd.close();
         mediaPlayers.put(audioId, newPlayer);
         handleDurationForPlayer(newPlayer, audioId);
         result.success(null);


### PR DESCRIPTION
Fixes issue where an Audio instance would call its onError callback before internal (in the Dart lib) cleanup had occurred. This would send spurious messages into the native implementation, creating NPEs on Android.

Closes #25 