### PR TITLE
Add 'CallLog.Calls.NUMBER' to query projection when reading device call records.

### DIFF
--- a/packages/phone_log/CHANGELOG.md
+++ b/packages/phone_log/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 0.0.6
-Added a fallback value for 'number' field in case CACHED_MATCHED_NUMBER is empty.
-
 ## 0.0.5
 Update tests to use mock call handler.
 

--- a/packages/phone_log/CHANGELOG.md
+++ b/packages/phone_log/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.6
+Added a fallback value for 'number' field in case CACHED_MATCHED_NUMBER is empty.
+
 ## 0.0.5
 Update tests to use mock call handler.
 

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
@@ -9,6 +9,7 @@ class CallRecord {
   String formattedNumber;
   String number;
   String callType;
+  String dialledNumber;
   int dateYear;
   int dateMonth;
   int dateDay;
@@ -29,6 +30,7 @@ class CallRecord {
     recordMap.put("dateMinute", dateMinute);
     recordMap.put("dateSecond", dateSecond);
     recordMap.put("duration", duration);
+    recordMap.put("dialledNumber", dialledNumber);
 
     return recordMap;
   }

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
@@ -6,10 +6,18 @@ class CallRecord {
 
   CallRecord() {}
 
+  // Note about the different number fields:
+  // Depending on how the number is dialed by the user
+  // i.e. manually entered through the device's dialpad,
+  // clicking on a contact or half-dialing the number
+  // and then clicking on the contact from the auto-
+  // complete suggestion, the number can be present in
+  // either the number, dialedNumber or formattedNumber
+  // field.
   String formattedNumber;
   String number;
-  String callType;
   String dialedNumber;
+  String callType;
   int dateYear;
   int dateMonth;
   int dateDay;

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
@@ -9,7 +9,7 @@ class CallRecord {
   String formattedNumber;
   String number;
   String callType;
-  String dialledNumber;
+  String dialedNumber;
   int dateYear;
   int dateMonth;
   int dateDay;
@@ -30,7 +30,7 @@ class CallRecord {
     recordMap.put("dateMinute", dateMinute);
     recordMap.put("dateSecond", dateSecond);
     recordMap.put("duration", duration);
-    recordMap.put("dialledNumber", dialledNumber);
+    recordMap.put("dialledNumber", dialedNumber);
 
     return recordMap;
   }

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
@@ -30,7 +30,7 @@ class CallRecord {
     recordMap.put("dateMinute", dateMinute);
     recordMap.put("dateSecond", dateSecond);
     recordMap.put("duration", duration);
-    recordMap.put("dialledNumber", dialedNumber);
+    recordMap.put("dialedNumber", dialedNumber);
 
     return recordMap;
   }

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/CallRecord.java
@@ -12,11 +12,9 @@ class CallRecord {
   // clicking on a contact or half-dialing the number
   // and then clicking on the contact from the auto-
   // complete suggestion, the number can be present in
-  // either the number, dialedNumber or formattedNumber
-  // field.
+  // either the number or formattedNumber field.
   String formattedNumber;
   String number;
-  String dialedNumber;
   String callType;
   int dateYear;
   int dateMonth;
@@ -38,7 +36,6 @@ class CallRecord {
     recordMap.put("dateMinute", dateMinute);
     recordMap.put("dateSecond", dateSecond);
     recordMap.put("duration", duration);
-    recordMap.put("dialedNumber", dialedNumber);
 
     return recordMap;
   }

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
@@ -100,6 +100,7 @@ public class PhoneLogPlugin
     CallLog.Calls.TYPE,
     CallLog.Calls.DATE,
     CallLog.Calls.DURATION,
+    CallLog.Calls.NUMBER,
   };
 
   @TargetApi(Build.VERSION_CODES.M)
@@ -157,14 +158,24 @@ public class PhoneLogPlugin
    */
   private ArrayList<HashMap<String, Object>> getCallRecordMaps(Cursor cursor) {
     ArrayList<HashMap<String, Object>> records = new ArrayList<>();
+    int formattedNumIndex = cursor.getColumnIndex(CallLog.Calls.CACHED_FORMATTED_NUMBER);
+    int cachedMatchedNumIndex = cursor.getColumnIndex(CallLog.Calls.CACHED_MATCHED_NUMBER);
+    int typeIndex = cursor.getColumnIndex(CallLog.Calls.TYPE);
+    int dateIndex = cursor.getColumnIndex(CallLog.Calls.DATE);
+    int durationIndex = cursor.getColumnIndex(CallLog.Calls.DURATION);
+    int dialledNumberIndex = cursor.getColumnIndex(CallLog.Calls.NUMBER);
 
     while (cursor != null && cursor.moveToNext()) {
       CallRecord record = new CallRecord();
-      record.formattedNumber = cursor.getString(0);
-      record.number = cursor.getString(1);
-      record.callType = getCallType(cursor.getInt(2));
+      // This number is formatted based on the country the user was in when the call was
+      // made/received.
+      record.formattedNumber = cursor.getString(formattedNumIndex);
+      record.number = cursor.getString(cachedMatchedNumIndex);
+      // This is the unformatted number when the call was made/received.
+      record.dialledNumber = cursor.getString(dialledNumberIndex);
+      record.callType = getCallType(cursor.getInt(typeIndex));
 
-      Date date = new Date(cursor.getLong(3));
+      Date date = new Date(cursor.getLong(dateIndex));
       Calendar cal = Calendar.getInstance();
       cal.setTime(date);
       record.dateYear = cal.get(Calendar.YEAR);
@@ -173,7 +184,7 @@ public class PhoneLogPlugin
       record.dateHour = cal.get(Calendar.HOUR_OF_DAY);
       record.dateMinute = cal.get(Calendar.MINUTE);
       record.dateSecond = cal.get(Calendar.SECOND);
-      record.duration = cursor.getLong(4);
+      record.duration = cursor.getLong(durationIndex);
 
       records.add(record.toMap());
     }

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
@@ -163,7 +163,7 @@ public class PhoneLogPlugin
     int typeIndex = cursor.getColumnIndex(CallLog.Calls.TYPE);
     int dateIndex = cursor.getColumnIndex(CallLog.Calls.DATE);
     int durationIndex = cursor.getColumnIndex(CallLog.Calls.DURATION);
-    int dialledNumberIndex = cursor.getColumnIndex(CallLog.Calls.NUMBER);
+    int dialedNumberIndex = cursor.getColumnIndex(CallLog.Calls.NUMBER);
 
     while (cursor != null && cursor.moveToNext()) {
       CallRecord record = new CallRecord();
@@ -172,7 +172,7 @@ public class PhoneLogPlugin
       record.formattedNumber = cursor.getString(formattedNumIndex);
       record.number = cursor.getString(cachedMatchedNumIndex);
       // This is the unformatted number when the call was made/received.
-      record.dialledNumber = cursor.getString(dialledNumberIndex);
+      record.dialedNumber = cursor.getString(dialedNumberIndex);
       record.callType = getCallType(cursor.getInt(typeIndex));
 
       Date date = new Date(cursor.getLong(dateIndex));

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
@@ -171,7 +171,7 @@ public class PhoneLogPlugin
       // made/received.
       record.formattedNumber = cursor.getString(formattedNumIndex);
       record.number = cursor.getString(cachedMatchedNumIndex);
-      // This is the unformatted number when the call was made/received.
+      // This is the unformatted number with which the call was made/received.
       record.dialedNumber = cursor.getString(dialedNumberIndex);
       record.callType = getCallType(cursor.getInt(typeIndex));
 

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
@@ -175,10 +175,9 @@ public class PhoneLogPlugin
       // was made/received.
       record.formattedNumber = cursor.getString(formattedNumIndex);
       // number holds the unformatted version of the actual number.
-      record.number = getUnformattedNumber(
-          cursor.getString(cachedMatchedNumIndex),
-          cursor.getString(dialedNumberIndex)
-      );
+      record.number =
+          getUnformattedNumber(
+              cursor.getString(cachedMatchedNumIndex), cursor.getString(dialedNumberIndex));
       record.callType = getCallType(cursor.getInt(typeIndex));
 
       Date date = new Date(cursor.getLong(dateIndex));

--- a/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
+++ b/packages/phone_log/android/src/main/java/com/jiajiabingcheng/phonelog/PhoneLogPlugin.java
@@ -150,6 +150,10 @@ public class PhoneLogPlugin
     }
   }
 
+  private String getUnformattedNumber(String cachedMatchedNum, String dialedNum) {
+    return (cachedMatchedNum == null || cachedMatchedNum.isEmpty()) ? dialedNum : cachedMatchedNum;
+  }
+
   /**
    * Builds the list of call record maps from the cursor
    *
@@ -167,12 +171,14 @@ public class PhoneLogPlugin
 
     while (cursor != null && cursor.moveToNext()) {
       CallRecord record = new CallRecord();
-      // This number is formatted based on the country the user was in when the call was
-      // made/received.
+      // This field  holds the number formatted based on the country the user was in when the call
+      // was made/received.
       record.formattedNumber = cursor.getString(formattedNumIndex);
-      record.number = cursor.getString(cachedMatchedNumIndex);
-      // This is the unformatted number with which the call was made/received.
-      record.dialedNumber = cursor.getString(dialedNumberIndex);
+      // number holds the unformatted version of the actual number.
+      record.number = getUnformattedNumber(
+          cursor.getString(cachedMatchedNumIndex),
+          cursor.getString(dialedNumberIndex)
+      );
       record.callType = getCallType(cursor.getInt(typeIndex));
 
       Date date = new Date(cursor.getLong(dateIndex));

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -43,8 +43,7 @@ class PhoneLog {
     final String _duration = duration?.toString();
 
     final Iterable<Map<dynamic, dynamic>> records = (await channel
-            .invokeMethod<List<dynamic>>(
-                'getPhoneLogs', <String, String>{
+            .invokeMethod<List<dynamic>>('getPhoneLogs', <String, String>{
       "startDate": _startDate,
       "duration": _duration
     }))

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -43,7 +43,7 @@ class PhoneLog {
     final String _duration = duration?.toString();
 
     final Iterable<Map<dynamic, dynamic>> records = (await channel
-            .invokeMethod<List<Map<String, dynamic>>>(
+            .invokeMethod<List<dynamic>>(
                 'getPhoneLogs', <String, String>{
       "startDate": _startDate,
       "duration": _duration

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -74,7 +74,6 @@ class CallRecord {
     this.dateMinute,
     this.dateSecond,
     this.duration,
-    this.dialedNumber,
   });
 
   CallRecord.fromMap(Map<String, Object> m) {

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -21,14 +21,15 @@ class PhoneLog {
 
   /// Check a [permission] and return a [Future] of the [PermissionStatus].
   Future<PermissionStatus> checkPermission() async {
-    final String status = await channel.invokeMethod("checkPermission", null);
+    final String status =
+        await channel.invokeMethod<String>("checkPermission", null);
     return permissionMap[status];
   }
 
   /// Request a [permission] and return a [Future] of bool.
   Future<bool> requestPermission() async {
     final bool isGranted =
-        await channel.invokeMethod("requestPermission", null);
+        await channel.invokeMethod<bool>("requestPermission", null);
     return isGranted;
   }
 
@@ -41,9 +42,11 @@ class PhoneLog {
     final String _startDate = startDate?.toString();
     final String _duration = duration?.toString();
 
-    final Iterable<Map<dynamic, dynamic>> records = (await channel.invokeMethod(
+    final Iterable<Map<dynamic, dynamic>> records = (
+        await channel.invokeMethod<List<Map<String, dynamic>>>(
             'getPhoneLogs',
-            <String, String>{"startDate": _startDate, "duration": _duration}))
+            <String, String>{"startDate": _startDate, "duration": _duration})
+    )
         ?.cast<Map<dynamic, dynamic>>();
     return records?.map((Map<dynamic, dynamic> m) =>
         new CallRecord.fromMap(m.cast<String, Object>()));

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -42,11 +42,12 @@ class PhoneLog {
     final String _startDate = startDate?.toString();
     final String _duration = duration?.toString();
 
-    final Iterable<Map<dynamic, dynamic>> records = (
-        await channel.invokeMethod<List<Map<String, dynamic>>>(
-            'getPhoneLogs',
-            <String, String>{"startDate": _startDate, "duration": _duration})
-    )
+    final Iterable<Map<dynamic, dynamic>> records = (await channel
+            .invokeMethod<List<Map<String, dynamic>>>(
+                'getPhoneLogs', <String, String>{
+      "startDate": _startDate,
+      "duration": _duration
+    }))
         ?.cast<Map<dynamic, dynamic>>();
     return records?.map((Map<dynamic, dynamic> m) =>
         new CallRecord.fromMap(m.cast<String, Object>()));

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -69,6 +69,7 @@ class CallRecord {
     this.dateMinute,
     this.dateSecond,
     this.duration,
+    this.dialedNumber,
   });
 
   CallRecord.fromMap(Map<String, Object> m) {
@@ -82,6 +83,7 @@ class CallRecord {
     dateMinute = m['dateMinute'];
     dateSecond = m['dateSecond'];
     duration = m['duration'];
+    dialedNumber = m['dialedNumber'];
   }
 
   String formattedNumber, number, callType;

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -61,6 +61,7 @@ class CallRecord {
   CallRecord({
     this.formattedNumber,
     this.number,
+    this.dialedNumber,
     this.callType,
     this.dateYear,
     this.dateMonth,
@@ -86,6 +87,6 @@ class CallRecord {
     dialedNumber = m['dialedNumber'];
   }
 
-  String formattedNumber, number, callType;
+  String formattedNumber, number, dialedNumber, callType;
   int dateYear, dateMonth, dateDay, dateHour, dateMinute, dateSecond, duration;
 }

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -64,7 +64,6 @@ class CallRecord {
   CallRecord({
     this.formattedNumber,
     this.number,
-    this.dialedNumber,
     this.callType,
     this.dateYear,
     this.dateMonth,
@@ -86,9 +85,8 @@ class CallRecord {
     dateMinute = m['dateMinute'];
     dateSecond = m['dateSecond'];
     duration = m['duration'];
-    dialedNumber = m['dialedNumber'];
   }
 
-  String formattedNumber, number, dialedNumber, callType;
+  String formattedNumber, number, callType;
   int dateYear, dateMonth, dateDay, dateHour, dateMinute, dateSecond, duration;
 }

--- a/packages/phone_log/pubspec.yaml
+++ b/packages/phone_log/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phone_log
 description: A new flutter plugin project.
-version: 0.0.5
+version: 0.0.6
 author: Jiaming Cheng <jiamingc@google.com>
 homepage: https://github.com/jiajiabingcheng/phone_log
 

--- a/packages/phone_log/pubspec.yaml
+++ b/packages/phone_log/pubspec.yaml
@@ -1,6 +1,6 @@
 name: phone_log
 description: A new flutter plugin project.
-version: 0.0.6
+version: 0.0.5
 author: Jiaming Cheng <jiamingc@google.com>
 homepage: https://github.com/jiajiabingcheng/phone_log
 

--- a/packages/phone_log/test/phone_log_test.dart
+++ b/packages/phone_log/test/phone_log_test.dart
@@ -41,7 +41,8 @@ void main() {
             'dateHour': 3,
             'dateMinute': 16,
             'dateSecond': 23,
-            'duration': 123
+            'duration': 123,
+            'dialedNumber': '1231231234',
           }
         ];
       } else {
@@ -77,6 +78,7 @@ void main() {
       expect(record.formattedNumber, '123 123 1234');
       expect(record.callType, 'INCOMING_TYPE');
       expect(record.number, '1231231234');
+      expect(record.dialedNumber, '1231231234');
       expect(record.dateYear, 2018);
       expect(record.duration, 123);
 

--- a/packages/phone_log/test/phone_log_test.dart
+++ b/packages/phone_log/test/phone_log_test.dart
@@ -42,7 +42,6 @@ void main() {
             'dateMinute': 16,
             'dateSecond': 23,
             'duration': 123,
-            'dialedNumber': '1231231234',
           }
         ];
       } else {
@@ -78,7 +77,6 @@ void main() {
       expect(record.formattedNumber, '123 123 1234');
       expect(record.callType, 'INCOMING_TYPE');
       expect(record.number, '1231231234');
-      expect(record.dialedNumber, '1231231234');
       expect(record.dateYear, 2018);
       expect(record.duration, 123);
 


### PR DESCRIPTION
**Reason for this addition:**
Based on how the number is dialed by the user (e.g. half dialing the number and selecting the contact, directly selecting the contact or typing the number entirely on the device's dialpad), the dialed number can be present in one of the three fields (_CACHED_FORMATTED_NUMBER_, _CACHED_MATCHED_NUMBER_ or _NUMBER_).

In order to cover all such cases, we need 'NUMBER' added to the projection query.