### PR TITLE
Remove dart:async imports that are no longer needed.

### DIFF
--- a/packages/phone_log/CHANGELOG.md
+++ b/packages/phone_log/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.7+1
+Removed a `dart:async` import that isn't required for \>=Dart 2.1.
+Require \>=Dart 2.1.
+
 ## 0.0.7
 Migrate to Android v2 embedding.
 

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/phone_log/pubspec.yaml
+++ b/packages/phone_log/pubspec.yaml
@@ -1,11 +1,11 @@
 name: phone_log
 description: A new flutter plugin project.
-version: 0.0.7
+version: 0.0.7+1
 author: Jiaming Cheng <jiamingc@google.com>
 homepage: https://github.com/jiajiabingcheng/phone_log
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/phone_log/test/phone_log_test.dart
+++ b/packages/phone_log/test/phone_log_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:flutter/services.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core. If
for some reason this package needs to continue to support Dart 2.0, an
exception can be made for these internally.