### PR TITLE
Fix audio playing for embedding v2

### DIFF
--- a/packages/audiofileplayer/example/.gitignore
+++ b/packages/audiofileplayer/example/.gitignore
@@ -26,6 +26,7 @@
 .pub-cache/
 .pub/
 /build/
+.flutter-plugins-dependencies
 
 # Android related
 **/android/**/gradle-wrapper.jar
@@ -59,6 +60,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 


### PR DESCRIPTION
When I'm running my app on channel beta, 1.22.0, there is an error with FlutterLoader. Essentially, what I'm seeing is that it is never initialized, but _a_ FlutterLoader is initialized as part of the embedding process so I didn't want to load it a second time.

This uses the new FlutterAssets interface, and wraps the registrar for the old embedding to implement this interface.