### PR TITLE
Migrate phone_log to null safety

### DIFF
--- a/packages/phone_log/CHANGELOG.md
+++ b/packages/phone_log/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.8
+Roll all dependencies.
+Migrate to null safety.
+
 ## 0.0.7+1
 Removed a `dart:async` import that isn't required for \>=Dart 2.1.
 Require \>=Dart 2.1.

--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -19,14 +19,14 @@ class PhoneLog {
 
   /// Check a [permission] and return a [Future] of the [PermissionStatus].
   Future<PermissionStatus> checkPermission() async {
-    final String status =
+    final String? status =
         await channel.invokeMethod<String>("checkPermission", null);
-    return permissionMap[status];
+    return permissionMap[status] ?? PermissionStatus.deniedAndCannotRequest;
   }
 
   /// Request a [permission] and return a [Future] of bool.
-  Future<bool> requestPermission() async {
-    final bool isGranted =
+  Future<bool?> requestPermission() async {
+    final bool? isGranted =
         await channel.invokeMethod<bool>("requestPermission", null);
     return isGranted;
   }
@@ -35,12 +35,12 @@ class PhoneLog {
   ///
   ///The unit of [startDate] is the Milliseconds of date.
   ///The unit of [duration] is second.
-  Future<Iterable<CallRecord>> getPhoneLogs(
-      {Int64 startDate, Int64 duration}) async {
-    final String _startDate = startDate?.toString();
-    final String _duration = duration?.toString();
+  Future<Iterable<CallRecord>?> getPhoneLogs(
+      {required Int64 startDate, required Int64 duration}) async {
+    final String _startDate = startDate.toString();
+    final String _duration = duration.toString();
 
-    final Iterable<Map<dynamic, dynamic>> records = (await channel
+    final Iterable<Map<dynamic, dynamic>>? records = (await channel
             .invokeMethod<List<dynamic>>('getPhoneLogs', <String, String>{
       "startDate": _startDate,
       "duration": _duration
@@ -51,10 +51,10 @@ class PhoneLog {
   }
 }
 
-Map<String, PermissionStatus> permissionMap = <String, PermissionStatus>{
+final permissionMap = <String?, PermissionStatus>{
   'granted': PermissionStatus.granted,
   'denied': PermissionStatus.denied,
-  'deniedAndCannotRequest': PermissionStatus.deniedAndCannotRequest
+  'deniedAndCannotRequest': PermissionStatus.deniedAndCannotRequest,
 };
 
 /// The class that carries all the data for one call history entry.
@@ -73,18 +73,18 @@ class CallRecord {
   });
 
   CallRecord.fromMap(Map<String, Object> m) {
-    formattedNumber = m['formattedNumber'];
-    number = m['number'];
-    callType = m['callType'];
-    dateYear = m['dateYear'];
-    dateMonth = m['dateMonth'];
-    dateDay = m['dateDay'];
-    dateHour = m['dateHour'];
-    dateMinute = m['dateMinute'];
-    dateSecond = m['dateSecond'];
-    duration = m['duration'];
+    formattedNumber = m['formattedNumber'] as String?;
+    number = m['number'] as String?;
+    callType = m['callType'] as String?;
+    dateYear = m['dateYear'] as int?;
+    dateMonth = m['dateMonth'] as int?;
+    dateDay = m['dateDay'] as int?;
+    dateHour = m['dateHour'] as int?;
+    dateMinute = m['dateMinute'] as int?;
+    dateSecond = m['dateSecond'] as int?;
+    duration = m['duration'] as int?;
   }
 
-  String formattedNumber, number, callType;
-  int dateYear, dateMonth, dateDay, dateHour, dateMinute, dateSecond, duration;
+  String? formattedNumber, number, callType;
+  int? dateYear, dateMonth, dateDay, dateHour, dateMinute, dateSecond, duration;
 }

--- a/packages/phone_log/pubspec.yaml
+++ b/packages/phone_log/pubspec.yaml
@@ -1,16 +1,15 @@
 name: phone_log
 description: A new flutter plugin project.
-version: 0.0.7+1
-author: Jiaming Cheng <jiamingc@google.com>
+version: 0.0.8
 homepage: https://github.com/jiajiabingcheng/phone_log
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  fixnum: ^0.10.7
+  fixnum: ^1.0.1
 
 # The following section is specific to Flutter.
 flutter:
@@ -19,6 +18,6 @@ flutter:
     pluginClass: PhoneLogPlugin
 
 dev_dependencies:
-  mockito: 3.0.0
+  mockito: ^5.2.0
   flutter_test:
     sdk: flutter

--- a/packages/phone_log/test/phone_log_test.dart
+++ b/packages/phone_log/test/phone_log_test.dart
@@ -4,17 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:phone_log/phone_log.dart';
 
-typedef Future<dynamic> Handler(MethodCall call);
+typedef Future<dynamic>? Handler(MethodCall call);
 
 void main() {
-  String invokedMethod;
+  String? invokedMethod;
   dynamic arguments;
-  Handler mockChannel;
-  Handler mockChannelForGetLogs;
-  Handler mockChannelForGranted;
-  Handler mockChannelForDenied;
-  Handler mockChannelForDeniedCannotRequest;
-  PhoneLog phoneLog;
+  Handler? mockChannel;
+  Handler? mockChannelForGetLogs;
+  Handler? mockChannelForGranted;
+  Handler? mockChannelForDenied;
+  Handler? mockChannelForDeniedCannotRequest;
+  late PhoneLog phoneLog;
 
   setUp(() {
     mockChannel = (MethodCall call) {
@@ -63,24 +63,25 @@ void main() {
     testWidgets('fetch phone log', (WidgetTester tester) async {
       channel.setMockMethodCallHandler(mockChannelForGetLogs);
 
-      final Iterable<CallRecord> records = await phoneLog.getPhoneLogs(
-          startDate: new Int64(123456789), duration: new Int64(12));
+      final Iterable<CallRecord>? records = await (phoneLog.getPhoneLogs(
+          startDate: new Int64(123456789), duration: new Int64(12)));
+      if (records != null) {
+        print(records);
+        final CallRecord record = records.first;
 
-      print(records);
-      final CallRecord record = records.first;
+        expect(record.formattedNumber, '123 123 1234');
+        expect(record.callType, 'INCOMING_TYPE');
+        expect(record.number, '1231231234');
+        expect(record.dateYear, 2018);
+        expect(record.duration, 123);
 
-      expect(record.formattedNumber, '123 123 1234');
-      expect(record.callType, 'INCOMING_TYPE');
-      expect(record.number, '1231231234');
-      expect(record.dateYear, 2018);
-      expect(record.duration, 123);
-
-      channel.setMockMethodCallHandler(mockChannel);
-      await phoneLog.getPhoneLogs(
-          startDate: new Int64(123456789), duration: new Int64(12));
-      expect(invokedMethod, 'getPhoneLogs');
-      expect(arguments,
-          <String, String>{'startDate': '123456789', 'duration': '12'});
+        channel.setMockMethodCallHandler(mockChannel);
+        await phoneLog.getPhoneLogs(
+            startDate: new Int64(123456789), duration: new Int64(12));
+        expect(invokedMethod, 'getPhoneLogs');
+        expect(arguments,
+            <String, String>{'startDate': '123456789', 'duration': '12'});
+      }
     });
 
     testWidgets('check permission', (WidgetTester tester) async {
@@ -92,19 +93,19 @@ void main() {
       expect(arguments, null);
 
       channel.setMockMethodCallHandler(mockChannelForGranted);
-      final PermissionStatus permissionGranted =
+      final PermissionStatus? permissionGranted =
           await phoneLog.checkPermission();
 
       expect(permissionGranted, PermissionStatus.granted);
 
       channel.setMockMethodCallHandler(mockChannelForDenied);
-      final PermissionStatus permissionDenied =
+      final PermissionStatus? permissionDenied =
           await phoneLog.checkPermission();
 
       expect(permissionDenied, PermissionStatus.denied);
 
       channel.setMockMethodCallHandler(mockChannelForDeniedCannotRequest);
-      final PermissionStatus permissionCannotRequest =
+      final PermissionStatus? permissionCannotRequest =
           await phoneLog.checkPermission();
 
       expect(permissionCannotRequest, PermissionStatus.deniedAndCannotRequest);


### PR DESCRIPTION
```
mit-macbookpro5:phone_log mit$ flutter analyze .
Analyzing phone_log...
No issues found! (ran in 2.8s)
mit-macbookpro5:phone_log mit$ flutter test
00:03 +0: Phone log plugin fetch phone log
(Instance of 'CallRecord')
00:03 +3: All tests passed!
```