### PR TITLE
Fix a null safety annotation

### DIFF
--- a/packages/phone_log/lib/phone_log.dart
+++ b/packages/phone_log/lib/phone_log.dart
@@ -51,7 +51,7 @@ class PhoneLog {
   }
 }
 
-final permissionMap = <String?, PermissionStatus>{
+final permissionMap = <String, PermissionStatus>{
   'granted': PermissionStatus.granted,
   'denied': PermissionStatus.denied,
   'deniedAndCannotRequest': PermissionStatus.deniedAndCannotRequest,


### PR DESCRIPTION
This was left over from an earlier migration where I had added a null entry to the map, and is no longer needed.