### PR TITLE
[audiofileplayer] Address dart:unnecessary_non_null_assertion warning

### DIFF
--- a/packages/audiofileplayer/lib/audiofileplayer.dart
+++ b/packages/audiofileplayer/lib/audiofileplayer.dart
@@ -245,7 +245,7 @@ class Audio with WidgetsBindingObserver {
         _absolutePath = null,
         _audioBytes = null,
         _remoteUrl = null {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   Audio._absolutePath(this._absolutePath, this._onComplete, this._onDuration,
@@ -254,7 +254,7 @@ class Audio with WidgetsBindingObserver {
         _path = null,
         _audioBytes = null,
         _remoteUrl = null {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   Audio._byteData(ByteData byteData, this._onComplete, this._onDuration,
@@ -264,7 +264,7 @@ class Audio with WidgetsBindingObserver {
         _path = null,
         _absolutePath = null,
         _remoteUrl = null {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   Audio._remoteUrl(this._remoteUrl, this._onComplete, this._onDuration,
@@ -273,7 +273,7 @@ class Audio with WidgetsBindingObserver {
         _audioBytes = null,
         _path = null,
         _absolutePath = null {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   static final Uuid _uuid = Uuid();
@@ -477,7 +477,7 @@ class Audio with WidgetsBindingObserver {
     // playing) it will be called when playback completes.
     if (!_playing) {
       _usingOnErrorAudios.remove(_audioId);
-      WidgetsBinding.instance!.removeObserver(this);
+      WidgetsBinding.instance.removeObserver(this);
       await _releaseNative(_audioId);
     }
   }
@@ -702,7 +702,7 @@ class Audio with WidgetsBindingObserver {
     if (undisposedAudio == null) {
       // The audio has been disposed, so release native resources.
       _usingOnErrorAudios.remove(audioId);
-      WidgetsBinding.instance!.removeObserver(playingAudio);
+      WidgetsBinding.instance.removeObserver(playingAudio);
       _releaseNative(audioId);
     }
 

--- a/packages/audiofileplayer/pubspec.yaml
+++ b/packages/audiofileplayer/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/google/flutter.plugins/tree/master/packages/audiofi
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR addresses https://github.com/google/flutter.plugins/issues/134 by fixing dart:unnecessary_non_null_assertion warning so that the package is compatible with Flutter version 3.0.0. Warning details: The '!' will have no effect because the receiver can't be null. Try removing the '!' operator.

[Warning about bindings in Flutter 3.0.0 release notes](https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#if-you-see-warnings-about-bindings)